### PR TITLE
Added hardware gamma check to texture creation

### DIFF
--- a/pluginTest/main.cpp
+++ b/pluginTest/main.cpp
@@ -117,6 +117,7 @@ int main()
 	//Create a window and a scene
 	NameValuePairList params;
 	params["FSAA"]	= "16";
+	params["gamma"]   = "true";
 	const auto window = root->createRenderWindow("glTF test!", 800, 600, false, &params);
 	auto smgr		  = root->createSceneManager(ST_GENERIC, 2, INSTANCING_CULLING_THREADED);
 	smgr->setForward3D(true, 4, 4, 5, 96, 3, 200);

--- a/src/Ogre_glTF_textureImporter.cpp
+++ b/src/Ogre_glTF_textureImporter.cpp
@@ -6,6 +6,8 @@
 #include <OgreImage.h>
 #include <OgreHardwarePixelBuffer.h>
 #include <OgreColourValue.h>
+#include <OgreRoot.h>
+#include <OgreRenderTarget.h>
 
 using namespace Ogre_glTF;
 
@@ -74,11 +76,25 @@ void textureImporter::loadTexture(const tinygltf::Texture& texture)
 											   1,
 											   1,
 											   pixelFormat,
-											   Ogre::TU_DEFAULT);
+											   Ogre::TU_DEFAULT,
+											   nullptr,
+											   IsHwGammaEnabled());
 
 	OgreTexture->loadImage(OgreImage);
 
 	loadedTextures.insert({ texture.source, OgreTexture });
+}
+
+bool textureImporter::IsHwGammaEnabled() const
+{
+	bool isHwGammaEnabled = false;
+
+	auto renderTargetIt = Ogre::Root::getSingleton().getRenderSystem()->getRenderTargetIterator();
+	if(renderTargetIt.hasMoreElements())
+    { 
+		isHwGammaEnabled = renderTargetIt.current()->second->isHardwareGammaEnabled();
+	}
+	return isHwGammaEnabled;
 }
 
 textureImporter::textureImporter(tinygltf::Model& input) :
@@ -176,7 +192,9 @@ Ogre::TexturePtr textureImporter::generateGreyScaleFromChannel(int gltfTextureSo
 											   1,
 											   1,
 											   pixelFormat,
-											   Ogre::TU_DEFAULT);
+											   Ogre::TU_DEFAULT,
+											   nullptr,
+											   IsHwGammaEnabled());
 	OgreTexture->loadImage(OgreImage);
 	return OgreTexture;
 }
@@ -224,7 +242,9 @@ Ogre::TexturePtr textureImporter::getNormalSNORM(int gltfTextureSourceID)
 																1,
 																1,
 																pixelFormatSnorm,
-																Ogre::TU_DEFAULT);
+																Ogre::TU_DEFAULT,
+																nullptr,
+																IsHwGammaEnabled());
 
 	auto pixels = OgreTexture->getBuffer()->lock(
 		{ 0, 0, unsigned(image.width), unsigned(image.height) }, //PixelBox that take the whole image

--- a/src/private_headers/Ogre_glTF_textureImporter.hpp
+++ b/src/private_headers/Ogre_glTF_textureImporter.hpp
@@ -23,6 +23,9 @@ namespace Ogre_glTF
 		/// \param texture reference to the texture that we are loading
 		void loadTexture(const tinygltf::Texture& texture);
 
+		///Checks that is hardware gamma enabled
+		bool IsHwGammaEnabled() const;
+
 	public:
 		///Construct the texture importer object. Inrement the id counter
 		/// \param input reference to the model that we are loading


### PR DESCRIPTION
Textures were always created without hardware gamma correction even if render target was configured to use it.