### PR TITLE
Generate correct bounding boxes

### DIFF
--- a/src/Ogre_glTF_modelConverter.cpp
+++ b/src/Ogre_glTF_modelConverter.cpp
@@ -170,7 +170,6 @@ Ogre::MeshPtr modelConverter::getOgreMesh()
 	}
 
 	OgreMesh->_setBounds(boundingBox, true);
-	OgreMesh->_setBoundingSphereRadius(boundingBox.getRadius());
 	//OgreLog("Setting 'bounding sphere radius' from bounds : " + std::to_string(boundingBox.getRadius()));
 
 	return OgreMesh;
@@ -379,7 +378,7 @@ vertexBufferPart modelConverter::extractVertexBuffer(const std::pair<std::string
 		OgreLog("Updating bounding box size: ");
 		OgreLog("Setting Min size: " + std::to_string(minBounds.x) + " " + std::to_string(minBounds.y) + " " + std::to_string(minBounds.z));
 		OgreLog("Setting Max size: " + std::to_string(maxBounds.x) + " " + std::to_string(maxBounds.y) + " " + std::to_string(maxBounds.z));
-		boundingBox.merge(Ogre::Aabb(minBounds, maxBounds));
+		boundingBox.merge(Ogre::Aabb::newFromExtents(minBounds, maxBounds));
 	}
 
 	//geometryBuffer->_debugContentToLog();


### PR DESCRIPTION
- Ogre::Aabb's constructor doesn't take min/max as parameters. Using Ogre::Aabb::newFromExtents() to construct a correct Aabb with min/max positions.
- Ogre::Mesh calls `_setBoundingSphereRadius()` in the `_setBounds()`, so it's redundant to do it again.